### PR TITLE
Feat angle wrap

### DIFF
--- a/orbita2d_controller/src/poulpe.rs
+++ b/orbita2d_controller/src/poulpe.rs
@@ -446,24 +446,24 @@ fn find_raw_motor_offsets(
     let current_position = controller.inner.get_current_position()?;
     let mut current_axis_sensors = controller.inner.get_axis_sensors()?;
 
-    // remove motor offsets  
+    // remove motor offsets
     current_axis_sensors
         .iter_mut()
         .enumerate()
         .for_each(|(i, val)| {
             *val = wrap_to_pi(*val - motors_offset[i]);
-	});
+        });
 
     let mut current_axis_position = controller
         .kinematics
         .compute_inverse_kinematics(current_axis_sensors);
- 
+
     debug!("Current positions: {:?} current_axis_position: {:?} inverted_axis: {:?} motors_ratio: {:?} axis_offsets: {:?}", current_position, current_axis_position, inverted_axis, motors_ratio, motors_offset);
     debug!(
         "AXIS SENSOR: {:?}, AXIS POS: {:?}",
         current_axis_sensors, current_axis_position
     ); //TODO Handle NaN
- 
+
     current_axis_position
         .iter_mut()
         .enumerate()
@@ -476,62 +476,90 @@ fn find_raw_motor_offsets(
     Ok(current_axis_position)
 }
 
-// function wrapping an angle in radians to 
+// function wrapping an angle in radians to
 // the range [-pi, pi]
-fn wrap_to_pi(angle: f64) -> f64{
-    (( (angle + PI) % (2.0*PI)) + (2.0*PI)) % (2.0*PI) - PI
+fn wrap_to_pi(angle: f64) -> f64 {
+    (((angle + PI) % (2.0 * PI)) + (2.0 * PI)) % (2.0 * PI) - PI
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::Orbita2dConfig;
     use crate::poulpe::wrap_to_pi;
-    
+    use crate::Orbita2dConfig;
 
     // Custom assert_approx_eq macro to compare floating point values within a tolerance
     macro_rules! assert_approx_eq {
         ($left:expr, $right:expr, $tol:expr) => {
-            assert!(($left - $right).abs() < $tol, "{} is not approximately equal to {}, within a tolerance of {}", $left, $right, $tol);
+            assert!(
+                ($left - $right).abs() < $tol,
+                "{} is not approximately equal to {}, within a tolerance of {}",
+                $left,
+                $right,
+                $tol
+            );
         };
     }
 
     #[test]
     fn test_wrap_to_pi_positive() {
-        assert_approx_eq!(wrap_to_pi(3.0 * std::f64::consts::PI), -std::f64::consts::PI,1e-5);
-        assert_approx_eq!(wrap_to_pi(4.0 * std::f64::consts::PI), 0.0,1e-5);
+        assert_approx_eq!(
+            wrap_to_pi(3.0 * std::f64::consts::PI),
+            -std::f64::consts::PI,
+            1e-5
+        );
+        assert_approx_eq!(wrap_to_pi(4.0 * std::f64::consts::PI), 0.0, 1e-5);
     }
 
     #[test]
     fn test_wrap_to_pi_negative() {
-        assert_approx_eq!(wrap_to_pi(-3.0 * std::f64::consts::PI), -std::f64::consts::PI,1e-5);
+        assert_approx_eq!(
+            wrap_to_pi(-3.0 * std::f64::consts::PI),
+            -std::f64::consts::PI,
+            1e-5
+        );
         assert_approx_eq!(wrap_to_pi(-4.0 * std::f64::consts::PI), 0.0, 1e-5);
     }
 
     #[test]
     fn test_wrap_to_pi_within_range() {
-        assert_approx_eq!(wrap_to_pi(std::f64::consts::PI-0.001), std::f64::consts::PI-0.001,1e-5);
-        assert_approx_eq!(wrap_to_pi(-std::f64::consts::PI+0.1), -std::f64::consts::PI+0.1,1e-5);
-        assert_approx_eq!(wrap_to_pi(0.0), 0.0,1e-5);
+        assert_approx_eq!(
+            wrap_to_pi(std::f64::consts::PI - 0.001),
+            std::f64::consts::PI - 0.001,
+            1e-5
+        );
+        assert_approx_eq!(
+            wrap_to_pi(-std::f64::consts::PI + 0.1),
+            -std::f64::consts::PI + 0.1,
+            1e-5
+        );
+        assert_approx_eq!(wrap_to_pi(0.0), 0.0, 1e-5);
     }
 
     #[test]
     fn test_wrap_to_pi_small_angles() {
-        assert_approx_eq!(wrap_to_pi(std::f64::consts::FRAC_PI_4), std::f64::consts::FRAC_PI_4, 1e-5);
-        assert_approx_eq!(wrap_to_pi(-std::f64::consts::FRAC_PI_4), -std::f64::consts::FRAC_PI_4, 1e-5);
+        assert_approx_eq!(
+            wrap_to_pi(std::f64::consts::FRAC_PI_4),
+            std::f64::consts::FRAC_PI_4,
+            1e-5
+        );
+        assert_approx_eq!(
+            wrap_to_pi(-std::f64::consts::FRAC_PI_4),
+            -std::f64::consts::FRAC_PI_4,
+            1e-5
+        );
     }
 
     #[test]
     fn test_wrap_to_pi_large_angles() {
-        assert_approx_eq!(wrap_to_pi(100.0 * std::f64::consts::PI), 0.0,1e-5);
-        assert_approx_eq!(wrap_to_pi(-100.0 * std::f64::consts::PI), 0.0,1e-5);
+        assert_approx_eq!(wrap_to_pi(100.0 * std::f64::consts::PI), 0.0, 1e-5);
+        assert_approx_eq!(wrap_to_pi(-100.0 * std::f64::consts::PI), 0.0, 1e-5);
     }
 
     #[test]
     fn test_wrap_to_pi_random_values() {
-        assert_approx_eq!(wrap_to_pi(1.2), 1.2,1e-5);
-        assert_approx_eq!(wrap_to_pi(-5.7), 0.583185307179586,1e-5);
+        assert_approx_eq!(wrap_to_pi(1.2), 1.2, 1e-5);
+        assert_approx_eq!(wrap_to_pi(-5.7), 0.583185307179586, 1e-5);
     }
-
 
     #[test]
     fn parse_config() {


### PR DESCRIPTION
Wrapping the angle of the absolute sensors + offsets to the range of [-pi, pi> at the init. 

This means that at init all the axis of the arm positions will be transformed to this [-pi, pi> range. 

So for example if one arm's joint is moved to the angle of 3pi/2 at the init, it will be interpreted as -pi/2.
The same problem was here before this change as well, but the angle was wrapped between [0,2pi> and the switch between the two was not centered around the joint's 0 position but around the absolute sensor's 0 position. 

