### PR TITLE
Feat safe reset the position target on turn_on

### DIFF
--- a/orbita2d_system_hwi/src/orbita2d_system_hwi.cpp
+++ b/orbita2d_system_hwi/src/orbita2d_system_hwi.cpp
@@ -491,6 +491,14 @@ namespace orbita2d_system_hwi
 
     //   );
 
+
+    // check if turn on and if yes make sure to reset the target to the current position
+    if ( (hw_commands_torque_ != 0)  && (hw_commands_torque_ != hw_states_torque_))
+    {
+      hw_commands_position_[0] = hw_states_position_[0];
+      hw_commands_position_[1] = hw_states_position_[1];
+    }
+
     if (orbita2d_set_target_orientation(this->uid, &hw_commands_position_) != 0)
     {
       // ret=hardware_interface::return_type::ERROR;


### PR DESCRIPTION
This PR updates the `orbita2d_system_hwi` to make sure that on every turn on the target position is reset to the current position value. Also it makes sure that this new position is propagated to the `joint_commands`.